### PR TITLE
feat: add extension-provided code snippets

### DIFF
--- a/_extensions/div-reuse/_snippets.json
+++ b/_extensions/div-reuse/_snippets.json
@@ -1,0 +1,12 @@
+{
+	"Define reusable div": {
+		"prefix": "div-source",
+		"body": ["::: {#${1:my-div}}", "${2:Content to reuse.}", ":::"],
+		"description": "Define a named div for reuse"
+	},
+	"Reuse a div": {
+		"prefix": "div-reuse",
+		"body": ["::: {reuse=\"${1:my-div}\"}", ":::"],
+		"description": "Reuse the content of a previously defined div by ID"
+	}
+}


### PR DESCRIPTION
## Summary

- Add `_snippets.json` file providing VS Code code snippets for Quarto Wizard IntelliSense.
- Related: mcanouil/quarto-wizard#279

## Test plan

- [ ] Verify `_snippets.json` is valid JSON.
- [ ] Install extension in a Quarto project with Quarto Wizard and verify snippets appear in IntelliSense.