### PR TITLE
feat: rename element-attributes to attributes in schema

### DIFF
--- a/_extensions/div-reuse/_schema.yml
+++ b/_extensions/div-reuse/_schema.yml
@@ -1,12 +1,12 @@
 # _schema.yml for "div-reuse" filter extension
-# Describes element attributes for IDE tooling and runtime validation.
+# Describes attributes for IDE tooling and runtime validation.
 
-# Element attributes accepted by the filter on Div elements.
+# Attributes accepted by the filter on Div elements.
 # Used in: ::: {#target reuse="source-id"}
 
 $schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
 
-element-attributes:
+attributes:
   _any:
     reuse:
       type: string


### PR DESCRIPTION
## Summary

- Rename the `element-attributes` YAML key to `attributes` in `_schema.yml` to match the updated [Quarto Wizard schema specification](https://m.canouil.dev/quarto-wizard/reference/schema-specification.html).

## Test plan

- [ ] Verify IDE completion and hover still work for element attributes.