### PR TITLE
feat: add reuse transforms, variables, and reuse limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 1.4.0 (2026-05-28)
-
 ### New Features
 
 - feat: Add `reuse-filter` attribute that transforms reused content with `shift-headings=N`, `take=N`, and `id-remap=old->new` key/value pairs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## 1.4.0 (2026-05-28)
+
+### New Features
+
+- feat: Add `reuse-filter` attribute that transforms reused content with `shift-headings=N`, `take=N`, and `id-remap=old->new` key/value pairs.
+- feat: Add `reuse-take` attribute as a shortcut for partial reuse of the first N top-level blocks.
+- feat: Substitute `{{name}}` tokens inside reused content with values from the `div-reuse.vars` metadata namespace, including dotted paths for nested keys.
+- feat: Enforce an optional document-level `div-reuse.limit` that caps the number of times each source div may be reused.
+
+### Bug Fixes
+
+- fix: Reset per-document module-level state in a `Meta` pass to prevent leakage across batch renders.
+- fix: Deep-clone reused content so per-reuse transforms do not mutate the source div.
+
+### Documentation
+
+- docs: Document reuse into class-bearing divs, the limitation that Quarto smart callouts are expanded before user filters, the precedence of `reuse-take` over `reuse-filter` take, and the new metadata namespace.
+
 ## 1.3.1 (2026-04-15)
 
 ### Refactoring

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a Quarto extension applying the concept of "code reuse" to the content o
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-div-reuse@1.3.1
+quarto add mcanouil/quarto-div-reuse@1.4.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -48,11 +48,85 @@ Then, you can reuse any fenced div by using their ID in the following way:
 ```
 
 > [!IMPORTANT]
-> The "reuse" attribute acts like a copy-paste of the original `div` content.
-> Consequently, content and their attributes, including the ID, are duplicated.
-> This can result in unexpected behaviour if the same ID is used multiple times within the same document.
->
-> Therefore, it is recommended to use the "reuse" attribute primarily with text content.
+> The `reuse` attribute acts like a copy-paste of the original `div` content.
+> Consequently, content and their attributes, including identifiers, are duplicated.
+> This can result in unexpected behaviour if the same identifier is used multiple times within the same document.
+> Prefer the `reuse-filter` `id-remap` transform (see below) when the reused content carries identifiers.
+
+## Reuse transforms
+
+The `reuse-filter` attribute applies one or more transforms to the reused content before it is inserted.
+The value is a comma-separated list of `key=value` pairs.
+Supported keys are:
+
+- `shift-headings=N`: shift every heading level inside the reused content by `N` (positive deepens, negative promotes).
+  Resulting levels are clamped to `[1, 6]` with a warning when clamping occurs.
+- `take=N`: keep only the first `N` top-level blocks of the reused content (partial reuse).
+- `id-remap=old1->new1;old2->new2`: rename element identifiers on `Div`, `Span`, and `Header` elements in the reused content.
+  Use `;` to separate mappings.
+
+The dedicated `reuse-take` attribute is a shortcut for `take=N` and takes precedence over a `take` key in `reuse-filter`.
+
+```markdown
+::: {reuse="report" reuse-filter="shift-headings=1,take=2"}
+:::
+
+::: {reuse="figure-block" reuse-filter="id-remap=fig-source->fig-copy"}
+:::
+
+::: {reuse="report" reuse-take="1"}
+:::
+```
+
+## Variable substitution
+
+Tokens of the form `{{name}}` (with optional whitespace and dotted paths for nested keys) inside reused content are replaced with values from the `div-reuse.vars` metadata namespace.
+Unknown variables are left literal and emit a single warning per name.
+
+```yml
+div-reuse:
+  vars:
+    project: "Quarto Extensions"
+    author:
+      name: "Mickaël Canouil"
+```
+
+```markdown
+::: {#greeting}
+Hello from {{project}}, signed {{author.name}}.
+:::
+
+::: {reuse="greeting"}
+:::
+```
+
+## Reuse limit
+
+The optional `div-reuse.limit` metadata caps how many times each source div may be reused per document.
+Additional reuses beyond the limit are skipped with a warning.
+
+```yml
+div-reuse:
+  limit: 3
+```
+
+## Reusing into class-bearing divs
+
+A reuse destination may carry any classes or attributes the document needs.
+Only the children are replaced; the destination div's classes, identifier, and other attributes are preserved.
+
+```markdown
+::: {#card-body}
+Remember to commit early and often.
+:::
+
+::: {.bordered .p-3 reuse="card-body"}
+:::
+```
+
+> [!NOTE]
+> Quarto's smart callouts (`.callout-tip`, `.callout-note`, ...) are expanded before user filters run, so a `reuse` attribute on a `.callout-*` div fills the underlying div but not the rendered callout body.
+> To reuse content into a callout, place the callout inside the source div and reuse it as a whole.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a Quarto extension applying the concept of "code reuse" to the content o
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-div-reuse@1.4.0
+quarto add mcanouil/quarto-div-reuse@1.3.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/_extensions/div-reuse/_extension.yml
+++ b/_extensions/div-reuse/_extension.yml
@@ -1,6 +1,6 @@
 title: Div Reuse
 author: Mickaël Canouil
-version: 1.3.1
+version: 1.4.0
 quarto-required: ">=1.6.40"
 contributes:
   filters:

--- a/_extensions/div-reuse/_extension.yml
+++ b/_extensions/div-reuse/_extension.yml
@@ -1,6 +1,6 @@
 title: Div Reuse
 author: Mickaël Canouil
-version: 1.4.0
+version: 1.3.1
 quarto-required: ">=1.6.40"
 contributes:
   filters:

--- a/_extensions/div-reuse/_schema.yml
+++ b/_extensions/div-reuse/_schema.yml
@@ -11,3 +11,32 @@ attributes:
     reuse:
       type: string
       description: "Identifier of another div whose content should replace this div's content."
+    reuse-filter:
+      type: string
+      description: >-
+        Comma-separated key=value transforms applied to reused content. Supported keys:
+        "shift-headings=N" (shift heading levels, clamped to [1, 6]),
+        "take=N" (keep only the first N top-level blocks),
+        "id-remap=old1->new1;old2->new2" (rename element identifiers).
+    reuse-take:
+      type: number
+      description: >-
+        Shortcut for "reuse-filter=take=N". Keeps only the first N top-level blocks of the
+        reused content. Overrides any "take" value in "reuse-filter".
+
+metadata:
+  div-reuse:
+    type: object
+    description: "Document-level configuration for the div-reuse filter."
+    properties:
+      limit:
+        type: number
+        minimum: 0
+        description: >-
+          Maximum number of times each source div may be reused per document. Additional
+          reuses beyond the limit are skipped with a warning. Defaults to unlimited.
+      vars:
+        type: object
+        description: >-
+          Variables available for "{{name}}" substitution inside reused content. Nested
+          keys are accessed with dotted paths ("{{user.name}}").

--- a/_extensions/div-reuse/_snippets.json
+++ b/_extensions/div-reuse/_snippets.json
@@ -8,5 +8,20 @@
 		"prefix": "div-reuse",
 		"body": ["::: {reuse=\"${1:my-div}\"}", ":::"],
 		"description": "Reuse the content of a previously defined div by ID"
+	},
+	"Reuse a div with heading shift": {
+		"prefix": "div-reuse-shift",
+		"body": ["::: {reuse=\"${1:my-div}\" reuse-filter=\"shift-headings=${2:1}\"}", ":::"],
+		"description": "Reuse a div and shift heading levels"
+	},
+	"Reuse first N blocks of a div": {
+		"prefix": "div-reuse-take",
+		"body": ["::: {reuse=\"${1:my-div}\" reuse-take=\"${2:1}\"}", ":::"],
+		"description": "Reuse only the first N top-level blocks of a div"
+	},
+	"Reuse a div with identifier remap": {
+		"prefix": "div-reuse-remap",
+		"body": ["::: {reuse=\"${1:my-div}\" reuse-filter=\"id-remap=${2:old-id}->${3:new-id}\"}", ":::"],
+		"description": "Reuse a div and rename element identifiers in the copied content"
 	}
 }

--- a/_extensions/div-reuse/div-reuse.lua
+++ b/_extensions/div-reuse/div-reuse.lua
@@ -3,10 +3,10 @@
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
 
---- Extension name constant
+--- Extension name constant.
 local EXTENSION_NAME = 'div-reuse'
 
---- Load modules
+--- Load shared modules.
 local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
 
 --- Storage for div contents indexed by identifier.
@@ -20,6 +20,267 @@ local reuse_chain = {}
 --- Track which div identifiers have already shown the nested-identifier warning.
 --- @type table<string, boolean>
 local identifier_warning_shown = {}
+
+--- Track which variable names have already shown the unknown-variable warning.
+--- @type table<string, boolean>
+local variable_warning_shown = {}
+
+--- Track which source ids have already shown the heading-shift clamp warning.
+--- @type table<string, boolean>
+local shift_warning_shown = {}
+
+--- Track per-source-id reuse counts for the reuse-limit guard.
+--- @type table<string, integer>
+local reuse_counts = {}
+
+--- Document-level reuse limit. nil means unlimited. Reset in Meta.
+--- @type integer|nil
+local document_reuse_limit = nil
+
+--- Track whether the limit-reached warning has been emitted for a given id.
+--- @type table<string, boolean>
+local limit_warning_shown = {}
+
+--- Reset all per-document module-level state.
+--- Prevents state leakage across documents in batch renders.
+local function reset_state()
+  div_contents = {}
+  reuse_chain = {}
+  identifier_warning_shown = {}
+  variable_warning_shown = {}
+  shift_warning_shown = {}
+  reuse_counts = {}
+  limit_warning_shown = {}
+  document_reuse_limit = nil
+end
+
+--- Convert any metadata value to a plain string for variable substitution.
+--- @param value any The metadata value (string, MetaInlines, MetaBlocks, number, boolean)
+--- @return string The stringified value
+local function stringify_meta_value(value)
+  if value == nil then return '' end
+  if type(value) == 'string' then return value end
+  if type(value) == 'number' or type(value) == 'boolean' then
+    return tostring(value)
+  end
+  return pandoc.utils.stringify(value)
+end
+
+--- Resolve a dotted variable path against a metadata-like table.
+--- Returns nil if any path segment is missing.
+--- @param vars table The variables table (typically from document metadata)
+--- @param path string Dotted key path (e.g. "user.name").
+--- @return any|nil The resolved value or nil
+local function resolve_variable(vars, path)
+  if vars == nil then return nil end
+  local current = vars
+  for segment in path:gmatch('[^%.]+') do
+    if type(current) ~= 'table' then return nil end
+    current = current[segment]
+    if current == nil then return nil end
+  end
+  return current
+end
+
+--- Parse the reuse-filter attribute value into a structured options table.
+--- Syntax: comma-separated key=value pairs, for example:
+---   "shift-headings=1,take=2,id-remap=fig-a->fig-b;fig-c->fig-d".
+--- @param raw string|nil Raw attribute value
+--- @return table options Parsed options with fields shift_headings, take, id_remap
+local function parse_filter_attribute(raw)
+  --- @type table
+  local options = {
+    shift_headings = nil,
+    take = nil,
+    id_remap = {},
+  }
+  if raw == nil or raw == '' then return options end
+  for pair in tostring(raw):gmatch('[^,]+') do
+    local key, value = pair:match('^%s*([^=%s]+)%s*=%s*(.-)%s*$')
+    if key and value then
+      if key == 'shift-headings' then
+        options.shift_headings = tonumber(value)
+      elseif key == 'take' then
+        options.take = tonumber(value)
+      elseif key == 'id-remap' then
+        for mapping in value:gmatch('[^;]+') do
+          local arrow_start, arrow_end = mapping:find('->', 1, true)
+          if arrow_start ~= nil then
+            local old_id = mapping:sub(1, arrow_start - 1):match('^%s*(.-)%s*$')
+            local new_id = mapping:sub(arrow_end + 1):match('^%s*(.-)%s*$')
+            if old_id ~= nil and old_id ~= '' and new_id ~= nil and new_id ~= '' then
+              options.id_remap[old_id] = new_id
+            end
+          end
+        end
+      end
+    end
+  end
+  return options
+end
+
+--- Deep-clone an array of blocks.
+--- @param blocks table Array of Pandoc blocks
+--- @return table A list of cloned blocks
+local function clone_blocks(blocks)
+  local cloned = {}
+  for _, block in ipairs(blocks) do
+    if type(block) == 'table' and block.clone then
+      table.insert(cloned, block:clone())
+    else
+      table.insert(cloned, block)
+    end
+  end
+  return cloned
+end
+
+--- Substitute `{{name}}` tokens within a single Str element's text.
+--- Dotted names (`{{a.b}}`) are resolved as nested metadata keys.
+--- Unknown names are left literal with a one-shot warning.
+--- @param text string The Str text
+--- @param variables table Variables table (typically document metadata)
+--- @return string|nil The replaced text, or nil when nothing changed
+local function substitute_str_text(text, variables)
+  if not text:find('{{') then return nil end
+  local changed = false
+  local replaced = text:gsub('{{%s*([%w_%-%.]+)%s*}}', function(name)
+    local value = resolve_variable(variables, name)
+    if value == nil then
+      if not variable_warning_shown[name] then
+        variable_warning_shown[name] = true
+        log.log_warning(
+          EXTENSION_NAME,
+          'Variable "' .. name .. '" is not defined in metadata; leaving token literal.'
+        )
+      end
+      return '{{' .. name .. '}}'
+    end
+    changed = true
+    return stringify_meta_value(value)
+  end)
+  if not changed then return nil end
+  return replaced
+end
+
+--- Walk a content list to perform variable substitution on Str and Code inlines
+--- as well as RawBlock and CodeBlock contents.
+--- @param content table Array of Pandoc blocks
+--- @param variables table Variables table (typically document metadata)
+--- @return table The walked content
+local function apply_variable_substitution(content, variables)
+  if variables == nil then return content end
+  return pandoc.Blocks(content):walk({
+    Str = function(str)
+      local replaced = substitute_str_text(str.text, variables)
+      if replaced == nil then return nil end
+      return pandoc.Str(replaced)
+    end,
+    Code = function(code)
+      local replaced = substitute_str_text(code.text, variables)
+      if replaced == nil then return nil end
+      code.text = replaced
+      return code
+    end,
+    CodeBlock = function(block)
+      local replaced = substitute_str_text(block.text, variables)
+      if replaced == nil then return nil end
+      block.text = replaced
+      return block
+    end,
+    RawInline = function(raw)
+      local replaced = substitute_str_text(raw.text, variables)
+      if replaced == nil then return nil end
+      raw.text = replaced
+      return raw
+    end,
+    RawBlock = function(raw)
+      local replaced = substitute_str_text(raw.text, variables)
+      if replaced == nil then return nil end
+      raw.text = replaced
+      return raw
+    end,
+  })
+end
+
+--- Apply heading-level shift to all Header elements in the content.
+--- Clamps the resulting level to the [1, 6] range with a warning when clamping occurs.
+--- @param content table Array of Pandoc blocks
+--- @param shift integer The level delta (positive deepens, negative promotes)
+--- @param ref_id string The source identifier used for warning context
+--- @return table The walked content
+local function apply_heading_shift(content, shift, ref_id)
+  if shift == nil or shift == 0 then return content end
+  return pandoc.Blocks(content):walk({
+    Header = function(header)
+      local new_level = header.level + shift
+      if new_level < 1 or new_level > 6 then
+        if not shift_warning_shown[ref_id] then
+          shift_warning_shown[ref_id] = true
+          log.log_warning(
+            EXTENSION_NAME,
+            'Heading shift for reuse of "' .. ref_id ..
+            '" clamped to the [1, 6] range.'
+          )
+        end
+        if new_level < 1 then
+          new_level = 1
+        else
+          new_level = 6
+        end
+      end
+      header.level = new_level
+      return header
+    end,
+  })
+end
+
+--- Apply identifier remapping to Div, Span and Header elements in the content.
+--- @param content table Array of Pandoc blocks
+--- @param mapping table<string, string> old to new identifier mapping
+--- @return table The walked content
+local function apply_id_remap(content, mapping)
+  if next(mapping) == nil then return content end
+  return pandoc.Blocks(content):walk({
+    Div = function(div)
+      local new_id = mapping[div.identifier]
+      if new_id then div.identifier = new_id end
+      return div
+    end,
+    Span = function(span)
+      local new_id = mapping[span.identifier]
+      if new_id then span.identifier = new_id end
+      return span
+    end,
+    Header = function(header)
+      local new_id = mapping[header.identifier]
+      if new_id then header.identifier = new_id end
+      return header
+    end,
+  })
+end
+
+--- Take only the first `n` blocks from a content list.
+--- Negative or zero `n` returns the empty list with a warning.
+--- @param content table Array of Pandoc blocks
+--- @param n integer The number of leading blocks to keep
+--- @param ref_id string The source identifier used for warning context
+--- @return table The trimmed content
+local function apply_take(content, n, ref_id)
+  if n == nil then return content end
+  if n <= 0 then
+    log.log_warning(
+      EXTENSION_NAME,
+      'take=' .. tostring(n) .. ' on reuse of "' .. ref_id .. '" yields no content.'
+    )
+    return {}
+  end
+  if n >= #content then return content end
+  local trimmed = {}
+  for i = 1, n do
+    table.insert(trimmed, content[i])
+  end
+  return trimmed
+end
 
 --- Collect divs with identifiers for later reuse.
 --- Stores div content in the div_contents table indexed by the div's identifier.
@@ -38,9 +299,8 @@ end
 --- which helps detect potential issues with reused content.
 ---
 --- @param content table Array of pandoc elements to search through
---- @param ref_id string Reference identifier (currently unused but kept for future use)
 --- @return integer Number of divs with identifiers found in the content
-local function find_identifiers(content, ref_id)
+local function find_identifiers(content)
   --- @type integer Count of divs with identifiers
   local identifier_found = 0
   for _, inner_el in ipairs(content) do
@@ -48,64 +308,156 @@ local function find_identifiers(content, ref_id)
       identifier_found = identifier_found + 1
     end
     if inner_el.content then
-      identifier_found = identifier_found + find_identifiers(inner_el.content, ref_id)
+      identifier_found = identifier_found + find_identifiers(inner_el.content)
     end
   end
   return identifier_found
+end
+
+--- Read the document-level reuse limit from metadata.
+--- Accepts either `div-reuse.limit` or `extensions.div-reuse.limit`.
+--- @param meta table Document metadata
+--- @return integer|nil The numeric limit or nil when unset
+local function read_reuse_limit(meta)
+  local raw = nil
+  if meta['div-reuse'] and meta['div-reuse'].limit ~= nil then
+    raw = meta['div-reuse'].limit
+  elseif meta.extensions and meta.extensions[EXTENSION_NAME]
+      and meta.extensions[EXTENSION_NAME].limit ~= nil then
+    raw = meta.extensions[EXTENSION_NAME].limit
+  end
+  if raw == nil then return nil end
+  local value = tonumber(pandoc.utils.stringify(raw))
+  if value == nil or value < 0 then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Invalid reuse limit "' .. tostring(pandoc.utils.stringify(raw)) ..
+      '"; ignoring.'
+    )
+    return nil
+  end
+  return math.floor(value)
+end
+
+--- Document-level variables namespace for `{{variable}}` substitution.
+--- Variables come from `div-reuse.vars` (preferred) or `extensions.div-reuse.vars`.
+--- @type table|nil
+local document_variables = nil
+
+--- Resolve the variables table for the current document.
+--- @param meta table Document metadata
+--- @return table|nil The variables table or nil when unset
+local function read_variables(meta)
+  if meta['div-reuse'] and meta['div-reuse'].vars then
+    return meta['div-reuse'].vars
+  end
+  if meta.extensions and meta.extensions[EXTENSION_NAME]
+      and meta.extensions[EXTENSION_NAME].vars then
+    return meta.extensions[EXTENSION_NAME].vars
+  end
+  return nil
+end
+
+--- Meta pass: reset state and read configuration.
+--- @param meta table Document metadata
+--- @return table The unchanged metadata
+local function read_meta(meta)
+  reset_state()
+  document_reuse_limit = read_reuse_limit(meta)
+  document_variables = read_variables(meta)
+  return meta
 end
 
 --- Replace div content with content from a referenced div.
 --- If a div has a "reuse" attribute, replaces its content with the content
 --- from the div identified by that attribute. Warns if the reused content
 --- contains divs with identifiers, as this may cause issues. Detects and prevents
---- circular references.
+--- circular references. Honours reuse-filter, take, and id-remap attributes,
+--- applies variable substitution from metadata, and enforces the document-level
+--- reuse limit.
 ---
 --- @param el pandoc.Div The div element to potentially replace
 --- @return pandoc.Div The div with replaced content or the original div
 local function replace_divs(el)
-  if el.attributes['reuse'] then
-    --- @type string The identifier of the div to reuse
-    local ref_id = el.attributes['reuse']
+  if not el.attributes['reuse'] then return el end
 
-    -- Check for circular reference
-    if reuse_chain[ref_id] then
+  --- @type string The identifier of the div to reuse
+  local ref_id = el.attributes['reuse']
+
+  if reuse_chain[ref_id] then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Circular reference detected: Div "' .. ref_id ..
+      '" is already in the reuse chain. Skipping to prevent infinite loop.'
+    )
+    return el
+  end
+
+  if not div_contents[ref_id] then return el end
+
+  reuse_counts[ref_id] = (reuse_counts[ref_id] or 0) + 1
+  if document_reuse_limit ~= nil and reuse_counts[ref_id] > document_reuse_limit then
+    if not limit_warning_shown[ref_id] then
+      limit_warning_shown[ref_id] = true
       log.log_warning(
         EXTENSION_NAME,
-        'Circular reference detected: Div "' .. ref_id ..
-        '" is already in the reuse chain. Skipping to prevent infinite loop.'
+        'Reuse limit (' .. tostring(document_reuse_limit) ..
+        ') reached for "' .. ref_id .. '"; subsequent reuses are skipped.'
       )
-      return el
     end
-
-    if div_contents[ref_id] then
-      -- Add to reuse chain before processing
-      reuse_chain[ref_id] = true
-
-      el.content = div_contents[ref_id]
-      --- @type integer Number of divs with identifiers in reused content
-      local total_identifiers = find_identifiers(el.content, ref_id)
-      if total_identifiers > 0 and not identifier_warning_shown[ref_id] then
-        identifier_warning_shown[ref_id] = true
-        log.log_warning(
-          EXTENSION_NAME,
-          'Div "' .. ref_id .. '" has been reused but contains ' ..
-          total_identifiers .. ' Div(s) with an identifier.'
-        )
-      end
-
-      -- Remove from reuse chain after processing
-      reuse_chain[ref_id] = nil
-    end
+    return el
   end
+
+  reuse_chain[ref_id] = true
+
+  --- @type table Cloned content to avoid mutating the source
+  local content = clone_blocks(div_contents[ref_id])
+
+  --- @type table Parsed reuse-filter options
+  local filter_options = parse_filter_attribute(el.attributes['reuse-filter'])
+
+  --- @type integer|nil Take override from the dedicated attribute
+  local take_attr = tonumber(el.attributes['reuse-take'])
+  if take_attr ~= nil then filter_options.take = take_attr end
+
+  if filter_options.take ~= nil then
+    content = apply_take(content, filter_options.take, ref_id)
+  end
+  if filter_options.shift_headings ~= nil then
+    content = apply_heading_shift(content, filter_options.shift_headings, ref_id)
+  end
+  if next(filter_options.id_remap) ~= nil then
+    content = apply_id_remap(content, filter_options.id_remap)
+  end
+  if document_variables ~= nil then
+    content = apply_variable_substitution(content, document_variables)
+  end
+
+  el.content = content
+
+  --- @type integer Number of divs with identifiers in reused content
+  local total_identifiers = find_identifiers(el.content)
+  if total_identifiers > 0 and not identifier_warning_shown[ref_id] then
+    identifier_warning_shown[ref_id] = true
+    log.log_warning(
+      EXTENSION_NAME,
+      'Div "' .. ref_id .. '" has been reused but contains ' ..
+      total_identifiers .. ' Div(s) with an identifier.'
+    )
+  end
+
+  reuse_chain[ref_id] = nil
   return el
 end
 
 --- Pandoc filter configuration.
---- Defines a two-pass filter:
---- 1. First pass collects all divs with identifiers
---- 2. Second pass replaces divs with reuse attributes
+--- Defines a three-pass filter:
+--- 1. Meta pass resets per-document state and reads configuration.
+--- 2. First Div pass collects all divs with identifiers.
+--- 3. Second Div pass replaces divs with reuse attributes.
 --- @type table
 return {
+  { Meta = read_meta },
   { Div = collect_divs },
-  { Div = replace_divs }
+  { Div = replace_divs },
 }

--- a/_extensions/div-reuse/div-reuse.lua
+++ b/_extensions/div-reuse/div-reuse.lua
@@ -169,36 +169,23 @@ end
 --- @return table The walked content
 local function apply_variable_substitution(content, variables)
   if variables == nil then return content end
+  --- Mutate `el.text` in place when a substitution occurs; return el on change, nil otherwise.
+  local function substitute_text_field(el)
+    local replaced = substitute_str_text(el.text, variables)
+    if replaced == nil then return nil end
+    el.text = replaced
+    return el
+  end
   return pandoc.Blocks(content):walk({
     Str = function(str)
       local replaced = substitute_str_text(str.text, variables)
       if replaced == nil then return nil end
       return pandoc.Str(replaced)
     end,
-    Code = function(code)
-      local replaced = substitute_str_text(code.text, variables)
-      if replaced == nil then return nil end
-      code.text = replaced
-      return code
-    end,
-    CodeBlock = function(block)
-      local replaced = substitute_str_text(block.text, variables)
-      if replaced == nil then return nil end
-      block.text = replaced
-      return block
-    end,
-    RawInline = function(raw)
-      local replaced = substitute_str_text(raw.text, variables)
-      if replaced == nil then return nil end
-      raw.text = replaced
-      return raw
-    end,
-    RawBlock = function(raw)
-      local replaced = substitute_str_text(raw.text, variables)
-      if replaced == nil then return nil end
-      raw.text = replaced
-      return raw
-    end,
+    Code = substitute_text_field,
+    CodeBlock = substitute_text_field,
+    RawInline = substitute_text_field,
+    RawBlock = substitute_text_field,
   })
 end
 
@@ -222,11 +209,7 @@ local function apply_heading_shift(content, shift, ref_id)
             '" clamped to the [1, 6] range.'
           )
         end
-        if new_level < 1 then
-          new_level = 1
-        else
-          new_level = 6
-        end
+        new_level = math.max(1, math.min(6, new_level))
       end
       header.level = new_level
       return header
@@ -314,18 +297,27 @@ local function find_identifiers(content)
   return identifier_found
 end
 
+--- Look up a key inside the `div-reuse` metadata namespace.
+--- Accepts either `div-reuse.<key>` or `extensions.div-reuse.<key>`.
+--- @param meta table Document metadata
+--- @param key string The key inside the namespace
+--- @return any|nil The raw metadata value or nil when unset
+local function read_namespace_key(meta, key)
+  if meta['div-reuse'] and meta['div-reuse'][key] ~= nil then
+    return meta['div-reuse'][key]
+  end
+  if meta.extensions and meta.extensions[EXTENSION_NAME]
+      and meta.extensions[EXTENSION_NAME][key] ~= nil then
+    return meta.extensions[EXTENSION_NAME][key]
+  end
+  return nil
+end
+
 --- Read the document-level reuse limit from metadata.
---- Accepts either `div-reuse.limit` or `extensions.div-reuse.limit`.
 --- @param meta table Document metadata
 --- @return integer|nil The numeric limit or nil when unset
 local function read_reuse_limit(meta)
-  local raw = nil
-  if meta['div-reuse'] and meta['div-reuse'].limit ~= nil then
-    raw = meta['div-reuse'].limit
-  elseif meta.extensions and meta.extensions[EXTENSION_NAME]
-      and meta.extensions[EXTENSION_NAME].limit ~= nil then
-    raw = meta.extensions[EXTENSION_NAME].limit
-  end
+  local raw = read_namespace_key(meta, 'limit')
   if raw == nil then return nil end
   local value = tonumber(pandoc.utils.stringify(raw))
   if value == nil or value < 0 then
@@ -340,7 +332,6 @@ local function read_reuse_limit(meta)
 end
 
 --- Document-level variables namespace for `{{variable}}` substitution.
---- Variables come from `div-reuse.vars` (preferred) or `extensions.div-reuse.vars`.
 --- @type table|nil
 local document_variables = nil
 
@@ -348,14 +339,7 @@ local document_variables = nil
 --- @param meta table Document metadata
 --- @return table|nil The variables table or nil when unset
 local function read_variables(meta)
-  if meta['div-reuse'] and meta['div-reuse'].vars then
-    return meta['div-reuse'].vars
-  end
-  if meta.extensions and meta.extensions[EXTENSION_NAME]
-      and meta.extensions[EXTENSION_NAME].vars then
-    return meta.extensions[EXTENSION_NAME].vars
-  end
-  return nil
+  return read_namespace_key(meta, 'vars')
 end
 
 --- Meta pass: reset state and read configuration.

--- a/example.qmd
+++ b/example.qmd
@@ -52,7 +52,7 @@ This is a Quarto extension applying the concept of "code reuse" to the content o
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-div-reuse@1.4.0
+quarto add mcanouil/quarto-div-reuse@1.3.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/example.qmd
+++ b/example.qmd
@@ -84,17 +84,17 @@ Then, you can reuse any fenced div by using their ID in the following way:
 ```markdown
 ## Original Div
 
-:::: {#my-div}
+::: {#my-div}
 {{< lipsum >}}
 :::
 
 ## Reused Div
 
-:::: {reuse="my-div"}
+::: {reuse="my-div"}
 :::
 ```
 
-:::: {.callout-important}
+::: {.callout-important}
 
 The "reuse" attribute acts like a copy-paste of the original `div` content.
 
@@ -111,44 +111,44 @@ The new `reuse-filter` transforms and `{{variable}}` substitution help mitigate 
 ### Example 1
 
 ```markdown
-:::: {reuse="lipsum"}
+::: {reuse="lipsum"}
 :::
 ```
 
-:::: {reuse="lipsum"}
+::: {reuse="lipsum"}
 :::
 
 ### Example 2
 
 ```markdown
-:::: {#placeholder}
-![]({{< placeholder >}})
+::: {#placeholder}
+{{< placeholder >}}
 :::
 ```
 
-:::: {#placeholder}
-![]({{< placeholder >}})
+::: {#placeholder}
+{{< placeholder >}}
 :::
 
 ### Example 3
 
 ```markdown
-:::: {reuse="placeholder"}
+::: {reuse="placeholder"}
 :::
 ```
 
-:::: {reuse="placeholder"}
+::: {reuse="placeholder"}
 :::
 
 ### Example 4
 
 ```markdown
-:::: {#lipsum}
+::: {#lipsum}
 {{< lipsum 1 >}}
 :::
 ```
 
-:::: {#lipsum}
+::: {#lipsum}
 {{< lipsum 1 >}}
 :::
 
@@ -158,19 +158,19 @@ The new `reuse-filter` transforms and `{{variable}}` substitution help mitigate 
 Nested values are addressed with dotted paths.
 
 ```markdown
-:::: {#welcome}
+::: {#welcome}
 Welcome to {{project}}, brought to you by {{author.name}} in {{year}}.
 :::
 
-:::: {reuse="welcome"}
+::: {reuse="welcome"}
 :::
 ```
 
-:::: {#welcome}
+::: {#welcome}
 Welcome to {{project}}, brought to you by {{author.name}} in {{year}}.
 :::
 
-:::: {reuse="welcome"}
+::: {reuse="welcome"}
 :::
 
 ### Example 6: partial reuse with `reuse-take`
@@ -178,7 +178,7 @@ Welcome to {{project}}, brought to you by {{author.name}} in {{year}}.
 `reuse-take="1"` keeps only the first top-level block of the source.
 
 ```markdown
-:::: {#multi}
+::: {#multi}
 First paragraph kept in the partial reuse below.
 
 Second paragraph dropped by `reuse-take="1"`.
@@ -186,11 +186,11 @@ Second paragraph dropped by `reuse-take="1"`.
 Third paragraph also dropped.
 :::
 
-:::: {reuse="multi" reuse-take="1"}
+::: {reuse="multi" reuse-take="1"}
 :::
 ```
 
-:::: {#multi}
+::: {#multi}
 First paragraph kept in the partial reuse below.
 
 Second paragraph dropped by `reuse-take="1"`.
@@ -198,7 +198,7 @@ Second paragraph dropped by `reuse-take="1"`.
 Third paragraph also dropped.
 :::
 
-:::: {reuse="multi" reuse-take="1"}
+::: {reuse="multi" reuse-take="1"}
 :::
 
 ### Example 7: heading shift with `reuse-filter`
@@ -206,7 +206,7 @@ Third paragraph also dropped.
 `shift-headings=2` deepens every heading in the reused block by two levels, so the source's level-3 heading appears as a level-5 heading here.
 
 ```markdown
-:::: {#section-block}
+::: {#section-block}
 ### Source-level heading
 
 Some paragraph under the source heading.
@@ -216,11 +216,11 @@ Some paragraph under the source heading.
 Paragraph under the sub-heading.
 :::
 
-:::: {reuse="section-block" reuse-filter="shift-headings=2"}
+::: {reuse="section-block" reuse-filter="shift-headings=2"}
 :::
 ```
 
-:::: {#section-block}
+::: {#section-block}
 ### Source-level heading
 
 Some paragraph under the source heading.
@@ -230,7 +230,7 @@ Some paragraph under the source heading.
 Paragraph under the sub-heading.
 :::
 
-:::: {reuse="section-block" reuse-filter="shift-headings=2"}
+::: {reuse="section-block" reuse-filter="shift-headings=2"}
 :::
 
 ### Example 8: identifier remap
@@ -238,23 +238,23 @@ Paragraph under the sub-heading.
 The inner div identifier is remapped on reuse to avoid duplicate identifiers.
 
 ```markdown
-:::: {#labelled}
+::: {#labelled}
 ::: {#label-source}
 Content tagged with `#label-source`.
 :::
 :::
 
-:::: {reuse="labelled" reuse-filter="id-remap=label-source->label-copy"}
+::: {reuse="labelled" reuse-filter="id-remap=label-source->label-copy"}
 :::
 ```
 
-:::: {#labelled}
+::: {#labelled}
 ::: {#label-source}
 Content tagged with `#label-source`.
 :::
 :::
 
-:::: {reuse="labelled" reuse-filter="id-remap=label-source->label-copy"}
+::: {reuse="labelled" reuse-filter="id-remap=label-source->label-copy"}
 :::
 
 ### Example 9: reusing into a class-bearing div
@@ -262,22 +262,22 @@ Content tagged with `#label-source`.
 The destination div keeps its own classes and attributes; only its children are replaced by the source content.
 
 ```markdown
-:::: {#card-body}
+::: {#card-body}
 Remember to commit early and often.
 :::
 
-:::: {.bordered .p-3 reuse="card-body"}
+::: {.bordered .p-3 reuse="card-body"}
 :::
 ```
 
-:::: {#card-body}
+::: {#card-body}
 Remember to commit early and often.
 :::
 
-:::: {.bordered .p-3 reuse="card-body"}
+::: {.bordered .p-3 reuse="card-body"}
 :::
 
-:::: {.callout-note}
+::: {.callout-note}
 
 Quarto's smart callouts (`.callout-tip`, `.callout-note`, ...) are expanded before user filters run, so a `reuse` attribute on a `.callout-*` div fills the underlying div but not the rendered callout body.
 
@@ -290,9 +290,9 @@ To reuse content into a callout, wrap the reuse site in plain markdown and place
 With `div-reuse.limit: 1`, the second reuse of `#welcome` (Example 5 used its single allowance) is skipped with a warning and the destination div is left empty.
 
 ```markdown
-:::: {reuse="welcome"}
+::: {reuse="welcome"}
 :::
 ```
 
-:::: {reuse="welcome"}
+::: {reuse="welcome"}
 :::

--- a/example.qmd
+++ b/example.qmd
@@ -38,6 +38,13 @@ execute:
   echo: true
 filters:
   - div-reuse
+div-reuse:
+  limit: 1
+  vars:
+    project: "Quarto Extensions"
+    author:
+      name: "Mickaël Canouil"
+    year: 2026
 ---
 
 This is a Quarto extension applying the concept of "code reuse" to the content of a Markdown fenced div.
@@ -45,7 +52,7 @@ This is a Quarto extension applying the concept of "code reuse" to the content o
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-div-reuse@1.3.1
+quarto add mcanouil/quarto-div-reuse@1.4.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -95,7 +102,7 @@ Consequently, content and their attributes, including the ID, are duplicated.
 
 This can result in unexpected behaviour if the same ID is used multiple times within the same document.
 
-Therefore, it is recommended to use the "reuse" attribute primarily with text content.
+The new `reuse-filter` transforms and `{{variable}}` substitution help mitigate these issues for richer content.
 
 :::
 
@@ -143,4 +150,149 @@ Therefore, it is recommended to use the "reuse" attribute primarily with text co
 
 :::: {#lipsum}
 {{< lipsum 1 >}}
+:::
+
+### Example 5: variable substitution
+
+`{{name}}` tokens inside reused content are replaced from `div-reuse.vars` in the YAML front matter.
+Nested values are addressed with dotted paths.
+
+```markdown
+:::: {#welcome}
+Welcome to {{project}}, brought to you by {{author.name}} in {{year}}.
+:::
+
+:::: {reuse="welcome"}
+:::
+```
+
+:::: {#welcome}
+Welcome to {{project}}, brought to you by {{author.name}} in {{year}}.
+:::
+
+:::: {reuse="welcome"}
+:::
+
+### Example 6: partial reuse with `reuse-take`
+
+`reuse-take="1"` keeps only the first top-level block of the source.
+
+```markdown
+:::: {#multi}
+First paragraph kept in the partial reuse below.
+
+Second paragraph dropped by `reuse-take="1"`.
+
+Third paragraph also dropped.
+:::
+
+:::: {reuse="multi" reuse-take="1"}
+:::
+```
+
+:::: {#multi}
+First paragraph kept in the partial reuse below.
+
+Second paragraph dropped by `reuse-take="1"`.
+
+Third paragraph also dropped.
+:::
+
+:::: {reuse="multi" reuse-take="1"}
+:::
+
+### Example 7: heading shift with `reuse-filter`
+
+`shift-headings=2` deepens every heading in the reused block by two levels, so the source's level-3 heading appears as a level-5 heading here.
+
+```markdown
+:::: {#section-block}
+### Source-level heading
+
+Some paragraph under the source heading.
+
+#### Sub-heading in the source
+
+Paragraph under the sub-heading.
+:::
+
+:::: {reuse="section-block" reuse-filter="shift-headings=2"}
+:::
+```
+
+:::: {#section-block}
+### Source-level heading
+
+Some paragraph under the source heading.
+
+#### Sub-heading in the source
+
+Paragraph under the sub-heading.
+:::
+
+:::: {reuse="section-block" reuse-filter="shift-headings=2"}
+:::
+
+### Example 8: identifier remap
+
+The inner div identifier is remapped on reuse to avoid duplicate identifiers.
+
+```markdown
+:::: {#labelled}
+::: {#label-source}
+Content tagged with `#label-source`.
+:::
+:::
+
+:::: {reuse="labelled" reuse-filter="id-remap=label-source->label-copy"}
+:::
+```
+
+:::: {#labelled}
+::: {#label-source}
+Content tagged with `#label-source`.
+:::
+:::
+
+:::: {reuse="labelled" reuse-filter="id-remap=label-source->label-copy"}
+:::
+
+### Example 9: reusing into a class-bearing div
+
+The destination div keeps its own classes and attributes; only its children are replaced by the source content.
+
+```markdown
+:::: {#card-body}
+Remember to commit early and often.
+:::
+
+:::: {.bordered .p-3 reuse="card-body"}
+:::
+```
+
+:::: {#card-body}
+Remember to commit early and often.
+:::
+
+:::: {.bordered .p-3 reuse="card-body"}
+:::
+
+:::: {.callout-note}
+
+Quarto's smart callouts (`.callout-tip`, `.callout-note`, ...) are expanded before user filters run, so a `reuse` attribute on a `.callout-*` div fills the underlying div but not the rendered callout body.
+
+To reuse content into a callout, wrap the reuse site in plain markdown and place the callout inside the source div instead.
+
+:::
+
+### Example 10: reuse-limit guard
+
+With `div-reuse.limit: 1`, the second reuse of `#welcome` (Example 5 used its single allowance) is skipped with a warning and the destination div is left empty.
+
+```markdown
+:::: {reuse="welcome"}
+:::
+```
+
+:::: {reuse="welcome"}
 :::


### PR DESCRIPTION
Extends the `div-reuse` Quarto filter with content transforms, metadata-driven variable substitution, and a per-document reuse guard.

The filter now resets its module-level state in a `Meta` pass and deep-clones reused content before applying any transform, so the source div is never mutated and batch renders no longer share state.

- Add `reuse-filter` attribute that applies comma-separated transforms to reused content: `shift-headings=N` (clamped to `[1, 6]` with a warning), `take=N` (partial reuse of the first `N` top-level blocks), and `id-remap=old1->new1;old2->new2` (rename identifiers on `Div`, `Span`, and `Header` elements).
- Add `reuse-take` attribute as a dedicated shortcut for partial reuse; it overrides any `take` key inside `reuse-filter`.
- Substitute `{{name}}` tokens inside reused content with values from the `div-reuse.vars` metadata namespace, including dotted paths (`{{author.name}}`) for nested keys, with a one-shot warning per unknown variable.
- Enforce an optional document-level `div-reuse.limit` that caps the number of times each source div may be reused, skipping subsequent reuses with a single warning per source id.

- Reset per-document module-level state (collected divs, reuse chain, warning sets, reuse counts, limit, variables) in a new `Meta` pass to prevent leakage across batch renders.
- Deep-clone reused content so per-reuse transforms operate on a fresh AST and do not mutate the source div observed by subsequent reuses.

- Document the new `reuse-filter`, `reuse-take`, `div-reuse.vars`, and `div-reuse.limit` options in `README.md`.
- Document the precedence of `reuse-take` over `reuse-filter` `take`.
- Document the limitation that Quarto smart callouts (`.callout-*`) are expanded before user filters run, so a `reuse` attribute on a `.callout-*` div fills the underlying div but not the rendered callout body.
- Extend `example.qmd` with six new worked examples covering variable substitution, partial reuse, heading shift, identifier remap, class-bearing-div reuse, and the reuse-limit guard.

- Bump `_extension.yml` to `1.4.0`.
- Extend `_schema.yml` with `reuse-filter`, `reuse-take`, and the `div-reuse` metadata namespace (`limit`, `vars`).
- Extend `_snippets.json` with snippets for `reuse-filter` heading shift, `reuse-take`, and `id-remap`.
