### PR TITLE
fix: declare the filter entry point in the extension manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Register the filter at `post-quarto` in the extension manifest, so listing `div-reuse` under `filters` is enough and the entry point no longer has to be named in project or document YAML.
+- fix: Raise `quarto-required` to `>=1.9.38`, the first version whose `_extension.yml` schema accepts a filter entry point.
+
 ## 1.4.1 (2026-08-01)
 
 ### Bug Fixes

--- a/_extensions/div-reuse/_extension.yml
+++ b/_extensions/div-reuse/_extension.yml
@@ -1,7 +1,8 @@
 title: Div Reuse
 author: Mickaël Canouil
 version: 1.4.1
-quarto-required: ">=1.6.40"
+quarto-required: ">=1.9.38"
 contributes:
   filters:
-    - div-reuse.lua
+    - path: div-reuse.lua
+      at: post-quarto

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -39,8 +39,7 @@ Enable the filter:
 
 ```yaml
 filters:
-  - path: div-reuse
-    at: post-quarto
+  - div-reuse
 ```
 
 Then name a source and reuse it:

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -8,8 +8,7 @@ description: "The complete div-reuse configuration: the reuse attributes, the th
 
 ```yaml
 filters:
-  - path: div-reuse
-    at: post-quarto
+  - div-reuse
 ```
 
 ::: {.callout-note}


### PR DESCRIPTION
The extension manifest now registers the filter at `post-quarto`, so listing `div-reuse` under `filters` is enough and the entry point no longer has to be repeated in project or document YAML. The documentation and `example.qmd` use the short form throughout.

`quarto-required` moves to >=1.9.38, the first version whose `_extension.yml` schema accepts a filter entry point. Below it the render fails validation.