### PR TITLE
fix: Describe filter options under `options` in `_schema.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Describe `limit` and `vars` under `options` in `_schema.yml` rather than under a `metadata` section, which is not part of the extension schema, so editors complete and validate them. Target the Quarto Wizard v2 extension schema.
+
 ## 1.4.2 (2026-08-01)
 
 ### Bug Fixes

--- a/_extensions/div-reuse/_schema.yml
+++ b/_extensions/div-reuse/_schema.yml
@@ -1,10 +1,24 @@
 # _schema.yml for "div-reuse" filter extension
-# Describes attributes for IDE tooling and runtime validation.
-
-# Attributes accepted by the filter on Div elements.
+# Describes options and attributes for IDE tooling and runtime validation.
+#
+# Options are read from `div-reuse:` or `extensions.div-reuse:`.
+# Attributes are accepted by the filter on Div elements.
 # Used in: ::: {#target reuse="source-id"}
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
+
+options:
+  limit:
+    type: number
+    minimum: 0
+    description: >-
+      Maximum number of times each source div may be reused per document. Additional
+      reuses beyond the limit are skipped with a warning. Defaults to unlimited.
+  vars:
+    type: object
+    description: >-
+      Variables available for "{{name}}" substitution inside reused content. Nested
+      keys are accessed with dotted paths ("{{user.name}}").
 
 attributes:
   _any:
@@ -23,20 +37,3 @@ attributes:
       description: >-
         Shortcut for "reuse-filter=take=N". Keeps only the first N top-level blocks of the
         reused content. Overrides any "take" value in "reuse-filter".
-
-metadata:
-  div-reuse:
-    type: object
-    description: "Document-level configuration for the div-reuse filter."
-    properties:
-      limit:
-        type: number
-        minimum: 0
-        description: >-
-          Maximum number of times each source div may be reused per document. Additional
-          reuses beyond the limit are skipped with a warning. Defaults to unlimited.
-      vars:
-        type: object
-        description: >-
-          Variables available for "{{name}}" substitution inside reused content. Nested
-          keys are accessed with dotted paths ("{{user.name}}").


### PR DESCRIPTION
The `limit` and `vars` options sat under a top-level `metadata` section, which the extension schema does not define, so editors offered no completion or validation for them. Moves both under `options`, which is what the filter reads from `div-reuse` and `extensions.div-reuse`, and targets the Quarto Wizard v2 meta-schema.