### PR TITLE
build: update the vendored Lua modules to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - docs: Serve the extension's social card as the Open Graph image, so a shared link shows the card rather than the first image on the page. (#38)
 
+### Refactoring
+
+- build: Update the vendored Lua modules to 2.3.0, which includes the `schema-check` fix for an extension whose entry points are in a subdirectory. A module no longer carries a version line in its header, so its checksum changes only when its code changes. (#39)
+
 ## 1.5.0 (2026-09-07)
 
 ### New Features

--- a/_extensions/div-reuse/_dependencies.yml
+++ b/_extensions/div-reuse/_dependencies.yml
@@ -3,17 +3,17 @@ sources:
   quarto-lua-modules:
     origin: "https://github.com/mcanouil/quarto-lua-modules"
     fetch: "{origin}/releases/download/{version}/{file}"
-    version: "2.1.0"
+    version: "2.3.0"
     licence: MIT
     files:
       logging.lua:
-        sha256: "0c3ded6020d3739c91bb6a492328751b284d1ada5763a1b8ca6fc5536ac01c95"
+        sha256: "5d99ceb89c813fbe4491310e42b4a4cff62e11dda42f01b4f61f969aa58e0706"
         runtime: any
       schema-check.lua:
-        sha256: "2fda875db97479f69c2c4d49f3073ac6ec458cb502c08c380918fdfadcd1e799"
+        sha256: "7c4dc34f31b85ff7bc4e2511f73e2301377e964e57ea5374ad97e7817a10af4b"
         runtime: any
       string.lua:
-        sha256: "a80255adaf7b7f2588aecb127030d950379479a2a1b266efc5b943364ac96cf4"
+        sha256: "7801d2f217e803951313ef86f1f899cb6350a44cbb468b2d7c28dd6911a0fadc"
         runtime: any
   quarto-wizard:
     origin: "https://github.com/mcanouil/quarto-wizard"

--- a/_extensions/div-reuse/_vendor/quarto-lua-modules/logging.lua
+++ b/_extensions/div-reuse/_vendor/quarto-lua-modules/logging.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.1.0
 
 local M = {}
 

--- a/_extensions/div-reuse/_vendor/quarto-lua-modules/schema-check.lua
+++ b/_extensions/div-reuse/_vendor/quarto-lua-modules/schema-check.lua
@@ -3,11 +3,14 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.1.0
 ---
---- Holds the wiring that every extension would otherwise copy: read
---- `_schema.yml` once, check the document configuration against it, check one
---- shortcode call against it, and report what it finds through `logging`.
+--- Holds the wiring that every extension would otherwise copy: read the schema
+--- once, check the document configuration against it, check one shortcode call
+--- against it, and report what it finds through `logging`.
+---
+--- The schema is `_schema.yml` beside the entry point that runs. An extension
+--- whose entry points sit in a subdirectory names its own path instead, with
+--- `'../_schema.yml'` for one level down.
 ---
 --- The validator arrives as an argument rather than through `require`. A
 --- vendored copy of this module then knows nothing about where the validator
@@ -310,15 +313,23 @@ end
 -- PUBLIC API
 -- ============================================================================
 
---- Build a checker for one extension, reading `_schema.yml` once.
+--- Build a checker for one extension, reading its schema once.
 --- A schema that cannot be read is reported, and the checker it returns does
 --- nothing: `options` gives an empty table and `call` gives no message.
+---
+--- The path is resolved with `quarto.utils.resolve_path`, which answers
+--- relative to the entry point that is running rather than to the extension
+--- directory. An entry point in a subdirectory therefore has to say where the
+--- schema is, and the checker it builds belongs at file scope, so that the
+--- schema is read once for the render and not once for each call.
 --- @param validator table The validator, with `load_schema`, `validate`,
 ---   `validate_shortcode` and `extract_meta_options`
 --- @param extension_name string The extension name every message carries
+--- @param schema_path string|nil The schema to read, relative to the entry
+---   point that is running. Defaults to `_schema.yml`.
 --- @return Checker
---- @usage local checker = M.new(validator, 'iconify')
-function M.new(validator, extension_name)
+--- @usage local checker = M.new(validator, 'iconify', '../_schema.yml')
+function M.new(validator, extension_name, schema_path)
   --- @type Checker
   local checker = setmetatable({
     validator = validator,
@@ -329,7 +340,11 @@ function M.new(validator, extension_name)
     options_checked = false,
   }, Checker)
 
-  local loaded, err = validator.load_schema(quarto.utils.resolve_path('_schema.yml'))
+  -- The default is chosen here rather than in the signature, so a caller that
+  -- passes two arguments reads the same file it read before this argument
+  -- existed.
+  local loaded, err = validator.load_schema(
+    quarto.utils.resolve_path(schema_path or '_schema.yml'))
   if err then
     checker:_report('schema', err)
   else

--- a/_extensions/div-reuse/_vendor/quarto-lua-modules/string.lua
+++ b/_extensions/div-reuse/_vendor/quarto-lua-modules/string.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.1.0
 
 local M = {}
 


### PR DESCRIPTION
Updates the vendored Lua modules from 2.1.0 to 2.3.0 and repins each checksum.

The 2.3.0 release drops the `--- @version` line that every module carried. The release used to stamp that line at each version, so a module's bytes changed on every release even when its code did not, and a vendored copy could never match a later release by checksum. The manifest already records the version this extension took.

This repository was pinned at 2.1.0, so the update also brings the 2.2.0 fix that lets `schema-check` read the schema of an extension whose entry points are in a subdirectory.

Verified with `vendor.sh --check`, which reports every declared source at the version its origin publishes.